### PR TITLE
Move serial communication to a separate Python script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SOURCES := cluster-demo.cpp RectGauge.cpp RoundGauge.cpp Gauge.cpp DigitalGauge.
 #INCLUDEFLAGS=-I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/include/interface/vcos/pthreads -fPIC
 INCLUDEFLAGS := -I/opt/vc/include -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/include/interface/vcos/pthreads
 
-LIBFLAGS := -lraylib -lpthread -lGL -lm -ldl -lgbm -ldrm -lEGL -lwiringPi
+LIBFLAGS := -lraylib -lpthread -lGL -lm -ldl -lgbm -ldrm -lEGL -lzmq -lzmqpp -lsodium
 
 cluster-demo: $(SOURCES)
 	@rm -f $@

--- a/cluster-demo.cpp
+++ b/cluster-demo.cpp
@@ -20,7 +20,6 @@
 
 //#define DEBUG
 #define DEBUG_FPS
-//#define TEST
 
 int main() {
 
@@ -131,54 +130,12 @@ int main() {
     float water_press = 0.0f;
     float water_temp = 0.0f;
     float rpm = 0.0f;
-    float mph = 0.0f;
+    float mph = -1.0f;
     float fuel_qty = 0.0f;
-#ifdef TEST
-    float oil_press_inc = 0.1f;
-    float oil_temp_inc = 0.03f;
-    float water_press_inc = 0.01f;
-    float water_temp_inc = 0.03f;
-    float rpm_inc = 1.0f;
-    float mph_inc = 0.3f;
-    float fuel_qty_inc = -0.0003f;
-#endif
 
     time_t start_time = time(NULL);
 
     while (!WindowShouldClose() && time(NULL) < start_time + 60) {
-
-#ifdef TEST
-        rpm += rpm_inc;
-        oil_press += oil_press_inc;
-        oil_temp += oil_temp_inc;
-        water_press += water_press_inc;
-        water_temp += water_temp_inc;
-        mph += mph_inc;
-        fuel_qty += fuel_qty_inc;
-
-        if (rpm >= tachometer.get_max() || rpm <= tachometer.get_min()) {
-            rpm_inc *= -1;
-        }
-        if (oil_press >= oil_press_gauge.get_max() || oil_press <= oil_press_gauge.get_min()) {
-            oil_press_inc *= -1;
-        }
-        if (oil_temp >= oil_temp_gauge.get_max() || oil_temp <= oil_temp_gauge.get_min()) {
-            oil_temp_inc *= -1;
-        }
-        if (water_temp >= water_temp_gauge.get_max() || water_temp <= water_temp_gauge.get_min()) {
-            water_temp_inc *= -1;
-        }
-        if (water_press >= water_press_gauge.get_max() || water_press <= water_press_gauge.get_min()) {
-            water_press_inc *= -1;
-        }
-        if (mph >= speedometer.get_max() || mph <= speedometer.get_min()) {
-            mph_inc *= -1;
-        }
-        if (fuel_qty >= fuel_qty_gauge.get_max() || fuel_qty <= fuel_qty_gauge.get_min()) {
-            fuel_qty_inc *= -1;
-        }
-
-#else
 
         zmqpp::message message;
 
@@ -219,8 +176,6 @@ int main() {
         if (message_count == 0) {
             std::cout << "No message received.\n";
         }
-#endif
-
 #endif
 
         BeginDrawing();

--- a/read_gps.py
+++ b/read_gps.py
@@ -1,0 +1,236 @@
+#!/usr/bin/python3
+
+# Would it be better to use a proper GPS library? Perhaps. But I haven't found one that doesn't have a whole lot of baggage and isn't a pain to use, so I created this.
+# Actually, I may have copy-pasted a lot of this from something else a long long time ago. I don't really remember writing it. If I did, I'm sorry.
+
+import argparse
+import csv
+import os
+import serial
+import time
+import traceback
+
+_serial_gps = None
+
+debug = 0
+
+def debug_print(string, level=1):
+    if debug >= level:
+        print(string)
+
+def debug_print_error(exception, level=0):
+    if debug >= level:
+        print("{}: {}".format(time.time(), traceback.format_exc()))
+
+def nmea_to_iso_date(date):
+    return "{}{}{}".format(date[4:6], date[2:4], date[0:2])
+
+# In the NMEA message, the position gets transmitted as: 
+# DDMM.MMMMM, where DD denotes the degrees and MM.MMMMM denotes
+# the minutes. However, I want to convert this format to the following:
+# DD.MMMM. This method converts a transmitted string to the desired format
+def nmea_coords_to_degrees(nmea_coords):
+    
+    parts = nmea_coords.split(".")
+
+    if (len(parts) != 2): 
+        return nmea_coords
+
+    degrees_digits = len(parts[0]) - 2
+    
+    left = parts[0]
+    right = parts[1]
+    degrees = float(left[:degrees_digits])
+    minutes = float(left[degrees_digits:])
+    minutes_fractional = float("0." + right)
+    minutes += minutes_fractional
+
+    degrees += minutes / 60.0
+
+    return degrees
+
+def get_gps_time():
+    message_type = ""
+    data = {}
+    date_ = None
+    time_ = None
+    while date_ == None:
+        try:
+            data = get_position_data()
+        except Exception as e:
+            # there will be lots of errors here as the initial data will be incomplete; ignore them.
+            pass
+        if data and "type" in data and data["type"] == "$GPRMC" and data["status"] == "A":
+            date_ = data["date"]
+            time_ = data["utc"].split('.')[0]
+    return "{}-{}".format(date_, time_)
+
+# This method reads the data from the serial port, the GPS dongle is attached to, 
+# and then parses the NMEA messages it transmits.
+# gps is the serial port, that's used to communicate with the GPS adapter
+def get_position_data(blocking=True):
+    global _serial_gps
+    if not blocking and _serial_gps.in_waiting == 0:
+        return {}
+    try:
+        data = _serial_gps.readline().decode('utf-8')
+    except UnicodeDecodeError:
+        return
+    debug_print(data, 2)
+
+    message = data[0:6]
+    parts = data.split(",")
+
+    if (message == "$GPGGA"):
+        raw_type, raw_utc, raw_lat, raw_ns, raw_lon, raw_ew, raw_quality, raw_num_sv, raw_hdop, raw_msl_alt, raw_alt_unit, raw_geoid_separation, raw_geoid_sep_unit, reference_station_id, raw_checksum = parts
+
+        latitude = nmea_coords_to_degrees(raw_lat)
+        longitude = nmea_coords_to_degrees(raw_lon)
+        msl_altitude = float(raw_msl_alt)
+        altitude_unit = raw_alt_unit.lower()
+        geoid_separation = float(raw_geoid_separation)
+        geoid_sep_unit = raw_geoid_sep_unit.lower()
+        quality = int(raw_quality)
+        num_sv = int(raw_num_sv)
+
+        # TODO make custom classes for this, maybe don't even do it in python
+        return {
+            "type": raw_type,
+            "utc": raw_utc,
+            "latitude": latitude,
+            "ns": raw_ns,
+            "longitude": longitude,
+            "ew": raw_ew,
+            "altitude": msl_altitude,
+            "altitude_unit": altitude_unit,
+            "geoid_separation": geoid_separation,
+            "geoid_separation_unit": geoid_sep_unit,
+            "quality": quality,
+            "num_sv": num_sv,
+        }
+    elif message == "$GPRMC":
+        raw_type, raw_utc, raw_status, raw_lat, raw_ns, raw_lon, raw_ew, raw_speed, raw_track, raw_date, raw_var, unknown_extra, raw_checksum = parts
+
+        latitude = nmea_coords_to_degrees(raw_lat)
+        longitude = nmea_coords_to_degrees(raw_lon)
+        speed = float(raw_speed)
+        track = float(raw_track),
+        date = nmea_to_iso_date(raw_date)
+
+        return {
+            "type": raw_type,
+            "utc": raw_utc,
+            "latitude": latitude,
+            "ns": raw_ns,
+            "longitude": longitude,
+            "ew": raw_ew,
+            "speed_kmh": speed,
+            "track": track,
+            "date": date,
+            "status": raw_status,
+        }
+    else:
+        # TODO handle other NMEA messages and unsupported strings
+        return {}
+
+def setup_gps(serial_device):
+    global _serial_gps
+    ser = serial.Serial(serial_device, baudrate=9600, timeout=0.5)
+    ser.reset_input_buffer()
+    # TODO add support for setting the baud/sample rate to whatever you want and generating the command strings
+    ser.write(b"$PMTK251,57600*2C\r\n")
+    ser.close()
+    _serial_gps = serial.Serial(serial_device, baudrate = 57600, timeout = 0.5)
+    time.sleep(0.1)
+    _serial_gps.reset_input_buffer()
+    # make sure the gps sample rate command succeeds
+    while _serial_gps.readline() != b"$PMTK001,220,3*30\r\n":
+        _serial_gps.write(b"$PMTK220,200*2C\r\n")
+        _serial_gps.write(b"$PMTK220,100*2F\r\n")
+        gps_data = _serial_gps.readline()
+
+if __name__ == "__main__":
+    start = time.time()
+    running = True
+    parser = argparse.ArgumentParser(description="Log GPS data")
+    parser.add_argument("-d", "--output-dir", help="Directory to log CSV output", default=".")
+    parser.add_argument("-v", "--verbose", action='count', help="Verbose output", default=0)
+    parser.add_argument("-s", "--serial-device", help="Path to tty device to which GPS module is attached", default="/dev/ttyUSB0")
+    args = parser.parse_args()
+    debug = args.verbose
+
+    debug_print("Application started!")
+
+    setup_gps(args.serial_device)
+
+    current_data_cache = dict()
+    timestamp = 0
+
+    time_ = get_gps_time()
+    output_filename = os.path.join(args.output_dir, "auto_log_{}.csv".format(time_))
+
+    with open(output_filename, 'w', newline='') as csvfile:
+        fieldnames = [
+            "system_time",
+            "utc_date",
+            "utc_time",
+            "lat",
+            "ns",
+            "lon",
+            "ew",
+            "alt",
+            "alt_unit",
+            "speed",
+            "track",
+            "quality",
+            "num_sv",
+            "status",
+        ]
+        csv_writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
+        csv_writer.writeheader()
+        while running:
+            try:
+                data = get_position_data()
+                if data:
+                    if abs(float(data["utc"]) - timestamp) > 0.02:
+                        debug_print(current_data_cache, 2)
+                        if current_data_cache and "$GPGGA" in current_data_cache and "$GPRMC" in current_data_cache:
+                            fields = {
+                                "system_time": time.time(),
+                                "utc_date": current_data_cache["$GPRMC"]["date"],
+                                "utc_time": current_data_cache["$GPRMC"]["utc"],
+                                "lat": current_data_cache["$GPGGA"]["latitude"],
+                                "ns": current_data_cache["$GPGGA"]["ns"],
+                                "lon": current_data_cache["$GPGGA"]["longitude"],
+                                "ew": current_data_cache["$GPGGA"]["ew"],
+                                "alt": current_data_cache["$GPGGA"]["altitude"],
+                                "alt_unit": current_data_cache["$GPGGA"]["altitude_unit"],
+                                "speed": current_data_cache["$GPRMC"]["speed"],
+                                "track": current_data_cache["$GPRMC"]["track"],
+                                "quality": current_data_cache["$GPGGA"]["quality"],
+                                "num_sv": current_data_cache["$GPGGA"]["num_sv"],
+                                "status": current_data_cache["$GPRMC"]["status"],
+                            }
+                            debug_print("utc = {utc} lat = {lat:.5f}{ns} lon = {lon:.5f}{ew} alt={alt:.1f}{alt_unit} quality={qual} number sv={num_sv}".format(
+                                utc=fields["utc_time"],
+                                lat=fields["lat"],
+                                ns=fields["ns"],
+                                lon=fields["lon"],
+                                ew=fields["ew"],
+                                alt=fields["alt"],
+                                alt_unit=fields["alt_unit"],
+                                qual=fields["quality"],
+                                num_sv=fields["num_sv"],
+                            ))
+
+                            csv_writer.writerow(fields)
+                        current_data_cache = dict()
+                        timestamp = float(data["utc"])
+                    current_data_cache[data["type"]] = data
+
+            except KeyboardInterrupt:
+                running = False
+                _serial_gps.close()
+                debug_print("Application closed!")
+            except Exception as e:
+                debug_print_error(e)

--- a/read_sensors.py
+++ b/read_sensors.py
@@ -1,0 +1,91 @@
+import time
+import zmq
+
+import read_gps
+
+KMH_TO_MPH = 0.621371
+
+rpm_min = 0
+rpm_max = 6700
+rpm = rpm_min
+rpm_inc = 2
+oil_temp_min = 0
+oil_temp_max = 270
+oil_temp = oil_temp_min
+oil_temp_inc = .1
+oil_press_min = 0
+oil_press_max = 90
+oil_press = oil_press_min
+oil_press_inc = .05
+water_temp_min = 0
+water_temp_max = 240
+water_temp = water_temp_min
+water_temp_inc = .06
+water_press_min = 0
+water_press_max = 20
+water_press = water_press_min
+water_press_inc = .02
+fuel_min = 0
+fuel_max = 12
+fuel = fuel_min
+fuel_inc = 0.01
+mph = None
+latitude = None
+longitude = None
+
+start = time.time()
+
+context = zmq.Context()
+socket = context.socket(zmq.PUSH)
+socket.connect("tcp://localhost:9961")
+
+# TODO figure out what port the GPS module is connected to and use that. It might not be USB0.
+read_gps.setup_gps("/dev/ttyUSB0")
+
+loops = 0
+
+while time.time() - start < 10:
+    try:
+        gps_data = read_gps.get_position_data(blocking=False)
+        if "speed_kmh" in gps_data:
+            mph = gps_data["speed_kmh"] * KMH_TO_MPH
+            socket.send("MPH:{}".format(mph).encode())
+        else:
+            mph = None
+
+
+        socket.send("OP:{}".format(oil_press).encode())
+        socket.send("OT:{}".format(oil_temp).encode())
+        socket.send("WP:{}".format(water_press).encode())
+        socket.send("WT:{}".format(water_temp).encode())
+        socket.send("RPM:{}".format(rpm).encode())
+        socket.send("FUEL:{}".format(fuel).encode())
+
+        rpm += rpm_inc
+        oil_temp += oil_temp_inc
+        oil_press += oil_press_inc
+        water_temp += water_temp_inc
+        water_press += water_press_inc
+        fuel += fuel_inc
+
+        if rpm >= rpm_max or rpm <= rpm_min:
+            rpm_inc *= -1
+        if oil_temp >= oil_temp_max or oil_temp <= oil_temp_min:
+            oil_temp_inc *= -1
+        if oil_press >= oil_press_max or oil_press <= oil_press_min:
+            oil_press_inc *= -1
+        if water_temp >= water_temp_max or water_temp <= water_temp_min:
+            water_temp_inc *= -1
+        if water_press >= water_press_max or water_press <= water_press_min:
+            water_press_inc *= -1
+        if fuel >= fuel_max or fuel <= fuel_min:
+            fuel_inc *= -1
+
+        time.sleep(0.01)
+    except KeyboardInterrupt:
+        break
+    loops += 1
+
+print("DONE")
+print("{} loops.".format(loops))
+

--- a/rpi-setup.sh
+++ b/rpi-setup.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+# Install raylib and its dependencies
+START_DIR=`pwd`
+# the libraries after the # are needed only on desktop platform installs
+echo "================Installing Raylib and its dependencies================"
+#sudo apt install make git vim cmake libgles2-mesa-dev libgbm-dev libdrm-dev -y # libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev
+git clone https://github.com/raysan5/raylib.git
+cd raylib
+# choose one depending on environment
+#cmake -DPLATFORM=Desktop -DOPENGL_VERSION=2.1 -DPLATFORM_CPP=PLATFORM_DESKTOP -DGRAPHICS=GRAPHICS_API_OPENGL_21 .
+cmake -DPLATFORM=DRM -DOPENGL_VERSION="ES 2.0" -DPLATFORM_CPP=PLATFORM_DRM -DGRAPHICS=GRAPHICS_API_OPENGL_ES2 .
+#make
+#make install
+
+echo "================Installing 0MQ===================="
+apt install libzmq-dev -y
+# The rest may not be necessary?
+#cd $START_DIR
+#apt install libtool -y
+#git clone https://github.com/zeromq/libzmq.git
+#cd libzmq
+#./autogen.sh
+#./configure --with-libsodium && make && make install
+#sudo ldconfig
+
+echo "================Installing ZMQPP==================="
+cd $START_DIR
+git clone https://github.com/zeromq/zmqpp.git
+cd zmqpp
+make
+make check
+make install
+make installcheck
+
+# This is needed by 0MQ for unclear reasons.
+apt install salt-master -y
+
+# Build the demo program
+echo "================Building demo program================"
+cd $START_DIR
+make
+EXEC_FILE=rpi-cluster
+
+# Make it run at boot time
+echo "================Creating and enabling service================"
+SERVICE_FILE=/lib/systemd/system/$EXEC_FILE.service
+touch $SERVICE_FILE
+echo "[Unit]" > $SERVICE_FILE
+echo "Description=Raylib Demo" >> $SERVICE_FILE
+echo "After=multi-user.target\n" >> $SERVICE_FILE
+echo "[Service]" >> $SERVICE_FILE
+echo "ExecStart=$START_DIR/$EXEC_FILE\n" >> $SERVICE_FILE
+echo "[Install]" >> $SERVICE_FILE
+echo "WantedBy=multi-user.target" >> $SERVICE_FILE
+systemctl daemon-reload
+systemctl enable $EXEC_FILE.service
+
+# Install PIP
+apt install python3-pip -y
+
+# Install and set up GPS libraries
+apt install gpsd gpsd-clients -y
+systemctl stop gpsd.socket
+systemctl disable gpsd.socket
+# TODO verify this is the correct tty file
+gpsd /dev/ttyUSB0 -F /var/run/gpsd.sock
+pip install gps
+
+# Install python serial communication library
+pip install pyserial
+# Install 0MQ for Python
+pip install pyzmq
+
+#apt install libsodium-dev -y

--- a/test_loop.py
+++ b/test_loop.py
@@ -1,0 +1,79 @@
+import os
+import posix
+import time
+import zmq
+
+rpm_min = 0
+rpm_max = 6700
+rpm = rpm_min
+rpm_inc = 2
+oil_temp_min = 0
+oil_temp_max = 270
+oil_temp = oil_temp_min
+oil_temp_inc = .1
+oil_press_min = 0
+oil_press_max = 90
+oil_press = oil_press_min
+oil_press_inc = .05
+water_temp_min = 0
+water_temp_max = 240
+water_temp = water_temp_min
+water_temp_inc = .06
+water_press_min = 0
+water_press_max = 20
+water_press = water_press_min
+water_press_inc = .02
+mph_min = 0
+mph_max = 120
+mph = mph_min
+mph_inc = 0.016
+fuel_min = 0
+fuel_max = 12
+fuel = fuel_min
+fuel_inc = 0.01
+
+start = time.time()
+
+context = zmq.Context()
+socket = context.socket(zmq.PUSH)
+socket.connect("tcp://localhost:9961")
+
+while time.time() - start < 60:
+    try:
+        socket.send("OP:{}".format(oil_press).encode())
+        socket.send("OT:{}".format(oil_temp).encode())
+        socket.send("WP:{}".format(water_press).encode())
+        socket.send("WT:{}".format(water_temp).encode())
+        socket.send("RPM:{}".format(rpm).encode())
+        socket.send("MPH:{}".format(mph).encode())
+        socket.send("FUEL:{}".format(fuel).encode())
+
+        rpm += rpm_inc
+        oil_temp += oil_temp_inc
+        oil_press += oil_press_inc
+        water_temp += water_temp_inc
+        water_press += water_press_inc
+        mph += mph_inc
+        fuel += fuel_inc
+
+        if rpm >= rpm_max or rpm <= rpm_min:
+            rpm_inc *= -1
+        if oil_temp >= oil_temp_max or oil_temp <= oil_temp_min:
+            oil_temp_inc *= -1
+        if oil_press >= oil_press_max or oil_press <= oil_press_min:
+            oil_press_inc *= -1
+        if water_temp >= water_temp_max or water_temp <= water_temp_min:
+            water_temp_inc *= -1
+        if water_press >= water_press_max or water_press <= water_press_min:
+            water_press_inc *= -1
+        if mph >= mph_max or mph <= mph_min:
+            mph_inc *= -1
+        if fuel >= fuel_max or fuel <= fuel_min:
+            fuel_inc *= -1
+
+        time.sleep(0.01)
+    except KeyboardInterrupt:
+        break
+
+print("DONE")
+


### PR DESCRIPTION
Does what the title says. This has several advantages:

* As far as I can tell, the wiringPi library isn't really maintained anymore, and one of the links to the code found on the website suggests using a different library. PySerial is actively maintained.
* It cleans up the cluster code, so it really just runs the cluster now.
* I have existing Python code I can use to get the GPS data, which can now be fed to the cluster along with everything else.
* Data server scripts can be hot-swapped, making it easy to show off functionality or test new features.